### PR TITLE
docs(waitFor): add default docs to `waitFor`

### DIFF
--- a/src/retry.ts
+++ b/src/retry.ts
@@ -96,6 +96,12 @@ export async function retry<T>(action: () => T | Promise<T>, options?: IRetryOpt
   throw lastError || new Error(`failed after ${attemptCount} tries`);
 }
 
-export function waitFor<T>(action: () => T | Promise<T>, options?: IRetryOptions): Promise<T> {
-  return retry(action, { delay: 10, timeout: 1000, retries: Infinity, ...options });
+/**
+ * @param options defaults to `{delay: 10, timeout: 1000, retries: Infinity }`
+ */
+export function waitFor<T>(
+  action: () => T | Promise<T>,
+  options: IRetryOptions = { delay: 10, timeout: 1000, retries: Infinity }
+): Promise<T> {
+  return retry(action, { ...options });
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -99,9 +99,6 @@ export async function retry<T>(action: () => T | Promise<T>, options?: IRetryOpt
 /**
  * @param options defaults to `{delay: 10, timeout: 1000, retries: Infinity }`
  */
-export function waitFor<T>(
-  action: () => T | Promise<T>,
-  options: IRetryOptions = { delay: 10, timeout: 1000, retries: Infinity }
-): Promise<T> {
-  return retry(action, { ...options });
+export function waitFor<T>(action: () => T | Promise<T>, options: IRetryOptions): Promise<T> {
+  return retry(action, { delay: 10, timeout: 1000, retries: Infinity, ...options });
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -99,6 +99,6 @@ export async function retry<T>(action: () => T | Promise<T>, options?: IRetryOpt
 /**
  * @param options defaults to `{delay: 10, timeout: 1000, retries: Infinity }`
  */
-export function waitFor<T>(action: () => T | Promise<T>, options: IRetryOptions): Promise<T> {
+export function waitFor<T>(action: () => T | Promise<T>, options?: IRetryOptions): Promise<T> {
   return retry(action, { delay: 10, timeout: 1000, retries: Infinity, ...options });
 }


### PR DESCRIPTION
JSDocs of `IRetryOptions` says it's default values are different then actual default.. fixed JSDocs to be clearer