### PR TITLE
feat: timeout callback message

### DIFF
--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -11,10 +11,13 @@
 export function timeout<T>(
   originalPromise: Promise<T>,
   ms: number,
-  timeoutMessage = `timed out after ${ms}ms`
+  timeoutMessage: string | (() => string) = `timed out after ${ms}ms`
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timerId = setTimeout(() => reject(new Error(timeoutMessage)), ms);
+    const timerId = setTimeout(
+      () => reject(new Error(typeof timeoutMessage === 'function' ? timeoutMessage() : timeoutMessage)),
+      ms
+    );
 
     originalPromise.then(
       (resolvedValue) => {

--- a/test/timeout.spec.ts
+++ b/test/timeout.spec.ts
@@ -20,4 +20,8 @@ describe('timeout', () => {
   it('allows providing a custom timeout message', async () => {
     await expect(timeout(sleep(200), 50, 'FAILED!')).to.eventually.be.rejectedWith('FAILED!');
   });
+
+  it('allows providing a custom timeout message from callback', async () => {
+    await expect(timeout(sleep(200), 50, () => 'FAILED!')).to.eventually.be.rejectedWith('FAILED!');
+  });
 });


### PR DESCRIPTION
This PR adds the ability to pass `timeout`  a failure message as a callback function for cases where the error message might contain information collected during the process