### PR TITLE
ci: test on Node 22 and 24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 20]
+        node-version: [24, 22]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prebuild": "npm run clean",
     "build": "tsc --build",
     "pretest": "npm run build",
-    "test": "node --test --enable-source-maps",
+    "test": "node --test --enable-source-maps \"dist/cjs/test/*.test.js\"",
     "prepack": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
explicitly specify glob to avoid auto loading of test sources, now that node supports running ts